### PR TITLE
Allow % in powershell source

### DIFF
--- a/ob-powershell.el
+++ b/ob-powershell.el
@@ -34,7 +34,7 @@ This function is called by `org-babel-execute-src-block'."
   (let ((scriptfile (org-babel-temp-file "powershell-script-" ".ps1"))
         (full-body (org-babel-expand-body:generic
 		                body params (org-babel-variable-assignments:powershell params))))
-    (message full-body)
+    (message "%s" full-body)
     (with-temp-file scriptfile (insert full-body))
     (org-babel-eval (concat ob-powershell-powershell-command " " scriptfile) "")))
 


### PR DESCRIPTION
Elisp's `message` takes a format string as its first argument, meaning it will try to expand anything after a `%`. We want to simply pass through the literal text value, so `(message "%s" full-body)` should be used to avoid the additional expansion.

If this is kept as-is, then any time the user attempts to execute powershell code with a `%` present, emacs presents a user error `Not enough arguments for format string`.